### PR TITLE
Fallback the browser name to Chrome if we don't know

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chesscom/cypress-image-diff-js",
-  "version": "1.18.12",
+  "version": "1.18.13",
   "description": "Visual regression testing tool with cypress",
   "main": "dist/command.js",
   "bin": {

--- a/src/command.js
+++ b/src/command.js
@@ -13,7 +13,7 @@ const compareSnapshotCommand = defaultScreenshotOptions => {
     { prevSubject: 'optional' },
     (subject, name, testThreshold = 0, recurseOptions = {}) => {
       const specName = Cypress.spec.name
-      const testName = `${specName.replace('.js', '')}-${name}.${globalThis.cypressBrowserName}`
+      const testName = `${specName.replace('.js', '')}-${name}.${globalThis.cypressBrowserName || 'chrome'}`
 
       const defaultRecurseOptions = {
         limit: 1,
@@ -43,7 +43,7 @@ const compareSnapshotCommand = defaultScreenshotOptions => {
             testName,
             testThreshold,
           }
-          
+
           return cy.task('compareSnapshotsPlugin', options)
         },
         (percentage) => percentage <= testThreshold,

--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ const paths = {
   },
   parentDir,
   reportDir,
-  report: instance => { return path.join(reportDir, `cypress-visual-report${instance}.${globalThis.cypressBrowserName}.html`) },
+  report: instance => { return path.join(reportDir, `cypress-visual-report${instance}.${globalThis.cypressBrowserName || 'chrome'}.html`) },
 }
 
 export default paths


### PR DESCRIPTION
Right now we're getting `undefined` in our browser screenshot images because `globalThis.cypressBrowserName` is `undefined`. 